### PR TITLE
callables and None are singletons like types are not considered for space calculation.

### DIFF
--- a/objsize.py
+++ b/objsize.py
@@ -20,8 +20,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import gc
-import sys
 import inspect
+import sys
 from typing import Optional, Iterable, Any
 
 
@@ -53,9 +53,13 @@ def traverse_bfs(*objs, marked: Optional[set] = None) -> Iterable[Any]:
 
         # Filter:
         #  - Object that are already marked (using the marked set).
+        #  - None - that one is a singleton
         #  - Type objects such as a class or a module as they are common among all objects.
+        #  - callable objects as they are common among all objects
         #  - Repeated objects (using dict notation).
-        objs = {o_id: o for o_id, o in objs if o_id not in marked and not isinstance(o, type)}
+        objs = {
+            o_id: o for o_id, o in objs if o_id not in marked and not (o is None or callable(o) or isinstance(o, type))
+        }
 
         # Update the marked set with the ids so we will not traverse them again.
         marked.update(objs.keys())

--- a/objsize.py
+++ b/objsize.py
@@ -45,7 +45,8 @@ def traverse_bfs(*objs, marked: Optional[set] = None) -> Iterable[Any]:
         The traversed objects, one by one.
     """
     if marked is None:
-        marked = set()
+        # None is a global singleton which doesn't need to be considered
+        marked = {id(None)}
 
     while objs:
         # Get the object's ids
@@ -53,12 +54,10 @@ def traverse_bfs(*objs, marked: Optional[set] = None) -> Iterable[Any]:
 
         # Filter:
         #  - Object that are already marked (using the marked set).
-        #  - None - that one is a singleton
         #  - Type objects such as a class or a module as they are common among all objects.
-        #  - callable objects as they are common among all objects
         #  - Repeated objects (using dict notation).
         objs = {
-            o_id: o for o_id, o in objs if o_id not in marked and not (o is None or callable(o) or isinstance(o, type))
+            o_id: o for o_id, o in objs if o_id not in marked and not isinstance(o, type)
         }
 
         # Update the marked set with the ids so we will not traverse them again.

--- a/objsize.py
+++ b/objsize.py
@@ -20,8 +20,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import gc
-import inspect
 import sys
+import inspect
 from typing import Optional, Iterable, Any
 
 
@@ -45,8 +45,10 @@ def traverse_bfs(*objs, marked: Optional[set] = None) -> Iterable[Any]:
         The traversed objects, one by one.
     """
     if marked is None:
-        # None is a global singleton which doesn't need to be considered
-        marked = {id(None)}
+        marked = set()
+
+    # None shouldn't be included in size calculations because it's a singleton
+    marked.add(id(None))
 
     while objs:
         # Get the object's ids
@@ -56,9 +58,7 @@ def traverse_bfs(*objs, marked: Optional[set] = None) -> Iterable[Any]:
         #  - Object that are already marked (using the marked set).
         #  - Type objects such as a class or a module as they are common among all objects.
         #  - Repeated objects (using dict notation).
-        objs = {
-            o_id: o for o_id, o in objs if o_id not in marked and not isinstance(o, type)
-        }
+        objs = {o_id: o for o_id, o in objs if o_id not in marked and not isinstance(o, type)}
 
         # Update the marked set with the ids so we will not traverse them again.
         marked.update(objs.keys())

--- a/test.py
+++ b/test.py
@@ -194,3 +194,25 @@ class TestDeepObjSize(unittest.TestCase):
 
         gc.collect()
         self.assertEqual(expected_sz, objsize.get_exclusive_deep_size(obj))
+
+    def test_class_with_callable(self):
+        class UnderTest:
+            def __init__(self, func, s):
+                self._func, self._s = func, s
+
+        # None doesn't occupy extra space because it is a singleton
+        obj = UnderTest(None, None)
+        expected_sz = sys.getsizeof(obj) + sys.getsizeof(obj.__dict__)
+
+        self.assertEqual(expected_sz, objsize.get_deep_size(obj))
+
+        # the string does occupy space
+        obj = UnderTest(None, 'x')
+        expected_sz += sys.getsizeof('x')
+
+        self.assertEqual(expected_sz, objsize.get_deep_size(obj))
+
+        # A callable again doesn't occupy extra space because it already is also a singleton
+        obj = UnderTest(self.test_class_with_callable, 'x')
+
+        self.assertEqual(expected_sz, objsize.get_deep_size(obj))


### PR DESCRIPTION
Arguably interned strings (e.g. dict keys) and small integers shouldn't be considered as well