### PR TITLE
Support for Python 3.14

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Python 3.14 added the `f_generator` attribute to frame objects, making the frame-to-generator reference explicit. This causes `gc.get_referrers()` to return the generator as a referrer, which breaks the exclusive object detection in `traverse_exclusive_bfs()`.

This PR adds the generator's id to `frame_set` when the attribute exists, preventing objects from being incorrectly marked as non-exclusive.

Tested with Python 3.10 - 3.14.

Reference: https://docs.python.org/3.14/library/inspect.html